### PR TITLE
fix: use module to avoid nil db value

### DIFF
--- a/cmd/app/cli/cli.go
+++ b/cmd/app/cli/cli.go
@@ -10,5 +10,5 @@ import (
 )
 
 func Start(module fx.Option) {
-	app.New(appcontext.Declare(appcontext.EnvCLI)).Start(context.Background())
+	app.New(appcontext.Declare(appcontext.EnvCLI), module).Start(context.Background())
 }


### PR DESCRIPTION
Fixes issue #24 which was causing an error because the DB module was not being loaded resulting in a nil pointer.